### PR TITLE
Fixed expand parameter

### DIFF
--- a/Order.php
+++ b/Order.php
@@ -33,7 +33,7 @@ class Order extends ShipwireComponent
     {
         $params = [];
         if ($expand) {
-            $params['expand'] = 1;
+            $params['expand'] = 'all';
         }
         return $this->get($this->getRoute('orders/{id}', $orderId), $params);
     }


### PR DESCRIPTION
From https://www.shipwire.com/w/developers/orders/

"Expand order data in the response, instead of accessing directly via a URL (comma separated list). Valid values are `holds`, `items` , `returns` and `trackings`, `splitOrders`, or simply `all`. See resources `Holds`, `Items`, `Returns`, `Trackings` and `splitOrders` for information on the data model returned by this parameter."